### PR TITLE
Add pooch as a requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     napari
     numpy
     magicgui
+    pooch
     qtpy
 
 python_requires = >=3.8

--- a/src/napari_vesuvius/_sample_data.py
+++ b/src/napari_vesuvius/_sample_data.py
@@ -1,10 +1,6 @@
-"""
-This module is an example of a barebones sample data provider for napari.
+""" Sample data contributions from the Vesuvius Challenge.
 
-It implements the "sample data" specification.
-see: https://napari.org/stable/plugins/guides.html?#sample-data
-
-Replace code below according to your needs.
+For details about the data, see: https://scrollprize.org/data
 """
 from pathlib import Path
 import pooch


### PR DESCRIPTION
Given that the sample data is pretty vital to get started, this adds `pooch` as a requirement. Alternatively, have a `data` extras would also be fine.

I also replaced the cookie-cutter sample data docstring with something relevant and concise.